### PR TITLE
Detect target inside a shadow root for clickOutsideHandler

### DIFF
--- a/packages/ckeditor5-ui/src/bindings/clickoutsidehandler.js
+++ b/packages/ckeditor5-ui/src/bindings/clickoutsidehandler.js
@@ -25,13 +25,14 @@
  * @param {Function} options.callback An action executed by the handler.
  */
 export default function clickOutsideHandler( { emitter, activator, callback, contextElements } ) {
-	emitter.listenTo( document, 'mousedown', ( evt, { target } ) => {
+	emitter.listenTo( document, 'mousedown', ( evt, domEvt ) => {
 		if ( !activator() ) {
 			return;
 		}
 
 		for ( const contextElement of contextElements ) {
-			if ( contextElement.contains( target ) ) {
+			if ( contextElement.contains( domEvt.target ) ||
+						( 'composedPath' in domEvt && domEvt.composedPath().includes( contextElement ) ) ) {
 				return;
 			}
 		}

--- a/packages/ckeditor5-ui/src/bindings/clickoutsidehandler.js
+++ b/packages/ckeditor5-ui/src/bindings/clickoutsidehandler.js
@@ -30,9 +30,9 @@ export default function clickOutsideHandler( { emitter, activator, callback, con
 			return;
 		}
 
+		const path = domEvt.composedPath !== undefined ? domEvt.composedPath() : [];
 		for ( const contextElement of contextElements ) {
-			if ( contextElement.contains( domEvt.target ) ||
-						( 'composedPath' in domEvt && domEvt.composedPath().includes( contextElement ) ) ) {
+			if ( contextElement.contains( domEvt.target ) || path.includes( contextElement ) ) {
 				return;
 			}
 		}

--- a/packages/ckeditor5-ui/src/bindings/clickoutsidehandler.js
+++ b/packages/ckeditor5-ui/src/bindings/clickoutsidehandler.js
@@ -30,6 +30,7 @@ export default function clickOutsideHandler( { emitter, activator, callback, con
 			return;
 		}
 
+		// Check if composedPath is undefined in case the browser does not support native shadow DOM
 		const path = domEvt.composedPath !== undefined ? domEvt.composedPath() : [];
 		for ( const contextElement of contextElements ) {
 			if ( contextElement.contains( domEvt.target ) || path.includes( contextElement ) ) {

--- a/packages/ckeditor5-ui/tests/bindings/clickoutsidehandler.js
+++ b/packages/ckeditor5-ui/tests/bindings/clickoutsidehandler.js
@@ -21,10 +21,14 @@ describe( 'clickOutsideHandler', () => {
 		activator = testUtils.sinon.stub().returns( false );
 		contextElement1 = document.createElement( 'div' );
 		contextElement2 = document.createElement( 'div' );
+
 		shadowRootContainer = document.createElement( 'div' );
-		shadowRootContainer.attachShadow( { mode: 'open' } );
-		shadowContextElement1 = document.createElement( 'div' );
-		shadowContextElement2 = document.createElement( 'div' );
+		if ( typeof shadowRootContainer.attachShadow === 'function' ) {
+			shadowRootContainer.attachShadow( { mode: 'open' } );
+			shadowContextElement1 = document.createElement( 'div' );
+			shadowContextElement2 = document.createElement( 'div' );
+		}
+
 		actionSpy = testUtils.sinon.spy();
 
 		document.body.appendChild( contextElement1 );
@@ -55,26 +59,10 @@ describe( 'clickOutsideHandler', () => {
 		sinon.assert.calledOnce( actionSpy );
 	} );
 
-	it( 'should execute upon #mousedown in the shadow root but outside the contextElements (activator is active)', () => {
-		activator.returns( true );
-
-		shadowRootContainer.shadowRoot.dispatchEvent( new Event( 'mousedown', { bubbles: true } ) );
-
-		sinon.assert.notCalled( actionSpy );
-	} );
-
 	it( 'should not execute upon #mousedown outside of the contextElements (activator is inactive)', () => {
 		activator.returns( false );
 
 		document.body.dispatchEvent( new Event( 'mousedown', { bubbles: true } ) );
-
-		sinon.assert.notCalled( actionSpy );
-	} );
-
-	it( 'should not execute upon #mousedown in the shadow root but outside of the contextElements (activator is inactive)', () => {
-		activator.returns( false );
-
-		shadowRootContainer.shadowRoot.dispatchEvent( new Event( 'mousedown', { bubbles: true } ) );
 
 		sinon.assert.notCalled( actionSpy );
 	} );
@@ -88,11 +76,13 @@ describe( 'clickOutsideHandler', () => {
 		contextElement2.dispatchEvent( new Event( 'mouseup', { bubbles: true } ) );
 		sinon.assert.notCalled( actionSpy );
 
-		shadowContextElement1.dispatchEvent( new Event( 'mouseup', { bubbles: true } ) );
-		sinon.assert.notCalled( actionSpy );
+		if ( typeof shadowRootContainer.attachShadow === 'function' ) {
+			shadowContextElement1.dispatchEvent( new Event( 'mouseup', { bubbles: true } ) );
+			sinon.assert.notCalled( actionSpy );
 
-		shadowContextElement2.dispatchEvent( new Event( 'mouseup', { bubbles: true } ) );
-		sinon.assert.notCalled( actionSpy );
+			shadowContextElement2.dispatchEvent( new Event( 'mouseup', { bubbles: true } ) );
+			sinon.assert.notCalled( actionSpy );
+		}
 	} );
 
 	it( 'should not execute upon #mousedown from one of the contextElements (activator is inactive)', () => {
@@ -104,11 +94,13 @@ describe( 'clickOutsideHandler', () => {
 		contextElement2.dispatchEvent( new Event( 'mouseup', { bubbles: true } ) );
 		sinon.assert.notCalled( actionSpy );
 
-		shadowContextElement1.dispatchEvent( new Event( 'mouseup', { bubbles: true } ) );
-		sinon.assert.notCalled( actionSpy );
+		if ( typeof shadowRootContainer.attachShadow === 'function' ) {
+			shadowContextElement1.dispatchEvent( new Event( 'mouseup', { bubbles: true } ) );
+			sinon.assert.notCalled( actionSpy );
 
-		shadowContextElement2.dispatchEvent( new Event( 'mouseup', { bubbles: true } ) );
-		sinon.assert.notCalled( actionSpy );
+			shadowContextElement2.dispatchEvent( new Event( 'mouseup', { bubbles: true } ) );
+			sinon.assert.notCalled( actionSpy );
+		}
 	} );
 
 	it( 'should execute if the activator function returns `true`', () => {
@@ -177,23 +169,39 @@ describe( 'clickOutsideHandler', () => {
 		sinon.assert.notCalled( actionSpy );
 	} );
 
-	it( 'should not execute if one of contextElements in the shadow root contains the DOM event target', () => {
-		const target = document.createElement( 'div' );
-		activator.returns( true );
+	it( 'should work with shadow root', () => {
+		if ( typeof shadowRootContainer.attachShadow === 'function' ) {
+			// Should execute upon #mousedown in the shadow root but outside the contextElements (activator is active)
+			activator.returns( true );
 
-		shadowContextElement1.appendChild( target );
-		target.dispatchEvent( new Event( 'mousedown', { bubbles: true } ) );
+			shadowRootContainer.shadowRoot.dispatchEvent( new Event( 'mousedown', { bubbles: true } ) );
 
-		sinon.assert.notCalled( actionSpy );
-	} );
+			sinon.assert.notCalled( actionSpy );
 
-	it( 'should not execute if one of contextElements in the shadow root is the DOM event target', () => {
-		const target = document.createElement( 'div' );
-		activator.returns( true );
+			// Should not execute upon #mousedown in the shadow root but outside of the contextElements (activator is inactive)
+			activator.returns( false );
 
-		shadowRootContainer.shadowRoot.appendChild( target );
-		target.dispatchEvent( new Event( 'mousedown', { bubbles: true } ) );
+			shadowRootContainer.shadowRoot.dispatchEvent( new Event( 'mousedown', { bubbles: true } ) );
 
-		sinon.assert.notCalled( actionSpy );
+			sinon.assert.notCalled( actionSpy );
+
+			// Should not execute if one of contextElements in the shadow root contains the DOM event target
+			const target1 = document.createElement( 'div' );
+			activator.returns( true );
+
+			shadowContextElement1.appendChild( target1 );
+			target1.dispatchEvent( new Event( 'mousedown', { bubbles: true } ) );
+
+			sinon.assert.notCalled( actionSpy );
+
+			// Should not execute if one of contextElements in the shadow root is the DOM event target
+			const target2 = document.createElement( 'div' );
+			activator.returns( true );
+
+			shadowRootContainer.shadowRoot.appendChild( target2 );
+			target2.dispatchEvent( new Event( 'mousedown', { bubbles: true } ) );
+
+			sinon.assert.notCalled( actionSpy );
+		}
 	} );
 } );


### PR DESCRIPTION
#### Suggested merge commit message, following CKEditor's [convention](https://ckeditor.com/docs/ckeditor5/latest/framework/guides/contributing/git-commit-message-convention.html):
Other (ui): Look at event's composed path to detect a target in shadow root. Closes #7743.

---

Looks at the event's composed path (when available) to add support for the editor being run in a shadow root. Due to event retargeting, `target` appears to be the entire editor when it's in a shadow root, causing a click to be seen as _not_ coming from a context element when it actually did. 
